### PR TITLE
Fix UDP bind race on slow Pico config queries; drop unused requests import

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,15 +122,35 @@ module.exports = function(app, options) {
       app.debug("listening on :" + address.address + ":" + address.port);
     });
 
-    // Do a delayed start to prevent address in use error
-    setTimeout (function () {
+    // Bind Node UDP only after pico.py exits.
+    //
+    // pico.py is a one-shot config dumper that binds UDP 43210 itself
+    // (with SO_REUSEPORT), waits for the first broadcast to discover
+    // the Pico IP, opens a TCP connection to query the sensor config,
+    // prints the resulting sensorList JSON, and exit(0)s. The TCP
+    // config query can take 30+s on cold boot or under load.
+    //
+    // The previous setTimeout(bind, 5000) hardcoded a delay too short
+    // for that scenario: Node would hit EADDRINUSE because pico.py was
+    // still holding the socket, no retry was attempted, and Node ended
+    // up never bound — plugin reports "Started" but pushes zero deltas.
+    //
+    // Binding on child.on('exit') instead fires exactly when pico.py
+    // releases the socket, with no timing assumption. The setTimeout
+    // is kept only as a safety net in case pico.py ever hangs.
+    let _udpBound = false;
+    function _doBind() {
+      if (_udpBound) return;
+      _udpBound = true;
       app.debug('Binding to port');
       socket.bind(port, function() {
         socket.setBroadcast(true);
-        const address = socket.address()
-        app.debug("Client using port " + address.port)
-      })
-    }, 5000);
+        const address = socket.address();
+        app.debug("Client using port " + address.port);
+      });
+    }
+    child.on('exit', _doBind);
+    setTimeout(_doBind, 90000); // safety net
 
     socket.on('error', function (err) {
       app.debug('Error: ' + err)

--- a/pico.py
+++ b/pico.py
@@ -5,7 +5,6 @@ import time
 import socket
 import sys
 import select
-import requests
 import json
 import brainsmoke
 import copy


### PR DESCRIPTION
Two small fixes that together make the plugin work reliably on cold boot in a stock `signalk/signalk-server` Docker container talking to a real Pico Yacht.

## Symptoms (before this PR)

After installing the plugin from the SignalK Appstore on a fresh container:

1. `pico.py` fails with `ModuleNotFoundError: No module named 'requests'` because the SignalK image has no `requests` installed. The plugin reports `Started` (no crash visible in the UI) but the spawned subprocess exits immediately and no `sensorList` is ever sent back to Node.
2. Once 1 is worked around (e.g. by `pip install requests` in the container), the plugin still fails on cold boot: it shows `Started` but pushes zero deltas. The configured Pico is reachable, UDP broadcasts on 43210 arrive at the host, but `vessels.self.electrical.batteries` and friends never populate.

## Root causes

**(1) `import requests` in `pico.py` is unused.** Nothing else in the file references the module. It looks like a leftover from earlier iteration.

**(2) UDP bind race.** `pico.py` binds UDP 43210 itself (with `SO_REUSEPORT`), then waits for the first broadcast to learn the Pico's IP, then opens a TCP connection to port 5001 to query the sensor configuration. That TCP query can take **30+ seconds** when the Pico is busy or just after a cold boot. While it runs, `pico.py` still holds the UDP socket.

The plugin's existing workaround was `setTimeout(bind, 5000)` to "avoid address-in-use" — a guess that 5 s would be enough for Python to be done. On the slow path it isn't: Node's bind fires at +5 s, hits `EADDRINUSE`, and the `socket.on('error', …)` handler only logs. There's no retry, so **Node never has a UDP socket**, every incoming broadcast is silently dropped, and `configRead = true` (which Node sets from Python's stdout) is meaningless without UDP arriving.

This is reliably reproducible on a Raspberry Pi cold boot; on warm restart it usually works because the Pico's TCP responds faster the second time around.

## Fix

Two commits:

1. **`Remove unused requests import in pico.py`** — one-line deletion. Eliminates a phantom Python dependency, makes the plugin work in any vanilla Python 3 environment.

2. **`Fix UDP bind race that prevents data flow on slow Pico config queries`** — replace the fixed `setTimeout(bind, 5000)` with `child.on('exit', bind)`. `pico.py` always `exit(0)`s after dumping the sensorList, so the exit event fires exactly when the UDP socket is released — no timing assumption needed. A 90 s `setTimeout` is kept as a safety net in case `pico.py` ever hangs.

## Verified

Tested on Raspberry Pi CM5 (HalOS) with a Pico Yacht. With these two patches applied:

- Warm restart: data flowing in ~1 s
- Cold boot: data flowing in ~10 s (Pico TCP query ~1.4 s, all clean)

Without either patch, cold boot leaves the plugin running but pushing zero deltas indefinitely.

## Related

Closes #8 type symptom (the EADDRINUSE here is the inverse of that earlier report — Node losing instead of Python).