### PR TITLE
Route each thermometer to its own SignalK path

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,15 +305,100 @@ module.exports = function(app, options) {
 	    // for key, value in sensorList.items():
       var updates = []
       var metas = []
+
+      // ===== Thermometer routing helpers =====
+      // Pre-pass: build (instance, normalizedKey) for every battery so we can
+      // resolve thermometer sensor names to a battery instance via flexible
+      // name matching.
+      function _normName(n) {
+        return String(n || '')
+          .toUpperCase()
+          .replace(/[\s_\-]+/g, ' ')
+          .replace(/\s+(BATTERY|BATTERIE|BANK)\s*$/, '')
+          .trim()
+      }
+      var _batteries = []
+      var _biScan = batteryInstance
+      for (const [, _v] of Object.entries(sensorList)) {
+        if (_v && _v['type'] === 'battery' && _v.name) {
+          _batteries.push({ instance: _biScan, key: _normName(_v.name) })
+          _biScan++
+        }
+      }
+
+      // Well-known thermometer name patterns -> canonical SignalK paths.
+      var _wellKnown = [
+        { re: /^(CABIN|INDOOR|INSIDE|MAIN CABIN|SALON|SALOON)$/,         path: 'environment.inside.temperature' },
+        { re: /^(OUTSIDE|OUTDOOR|EXTERIOR|AMBIENT|OUTSIDE AIR)$/,        path: 'environment.outside.temperature' },
+        { re: /^(SEAWATER|SEA WATER|SEA|RAW WATER|WATER)$/,              path: 'environment.water.temperature' },
+        { re: /^(ENGINE|ENGINE ROOM|ENGINEROOM|ENGINE BAY)$/,            path: 'environment.inside.engineRoom.temperature' },
+        { re: /^(REFRIGERATOR|FRIDGE)$/,                                 path: 'environment.inside.refrigerator.temperature' },
+        { re: /^(FREEZER)$/,                                             path: 'environment.inside.freezer.temperature' },
+        { re: /^(EXHAUST)$/,                                             path: 'propulsion.main.exhaustTemperature' },
+      ]
+
+      // Resolve a thermometer sensor name -> SignalK path.
+      function _thermometerPath(sensorName) {
+        var raw = String(sensorName || '').replace(/^TEMP[\s_\-]+/i, '').trim()
+        if (!raw) return 'environment.inside.temperature'
+        var upper = raw.toUpperCase()
+        var key = _normName(raw)
+
+        // 1. Battery match -- only attempt if name mentions BATTERY/BANK
+        if (/\b(BATTERY|BATTERIE|BANK)\b/.test(upper)) {
+          // Exact match
+          for (var i = 0; i < _batteries.length; i++) {
+            if (_batteries[i].key === key) {
+              return 'electrical.batteries.' + String(_batteries[i].instance) + '.temperature'
+            }
+          }
+          // Prefix match either direction (e.g. "BOW" matches "BOW THRUSTER")
+          for (var j = 0; j < _batteries.length; j++) {
+            var b = _batteries[j].key
+            if (b.indexOf(key + ' ') === 0 || key.indexOf(b + ' ') === 0) {
+              return 'electrical.batteries.' + String(_batteries[j].instance) + '.temperature'
+            }
+          }
+          // Token overlap (tokens of length >= 3 to avoid noise)
+          var keyTokens = key.split(/\s+/).filter(function(t) { return t.length >= 3 })
+          for (var k = 0; k < _batteries.length; k++) {
+            var bTokens = _batteries[k].key.split(/\s+/).filter(function(t) { return t.length >= 3 })
+            for (var t = 0; t < keyTokens.length; t++) {
+              if (bTokens.indexOf(keyTokens[t]) !== -1) {
+                return 'electrical.batteries.' + String(_batteries[k].instance) + '.temperature'
+              }
+            }
+          }
+          // No battery match -- fall through to slugified fallback
+        }
+
+        // 2. Well-known canonical paths
+        for (var w = 0; w < _wellKnown.length; w++) {
+          if (_wellKnown[w].re.test(upper)) return _wellKnown[w].path
+        }
+
+        // 3. Slugified fallback under environment.inside.<slug>.temperature
+        //    so each unknown sensor keeps a distinct, predictable path.
+        var slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
+        if (!slug) slug = 'sensor'
+        return 'environment.inside.' + slug + '.temperature'
+      }
+      // ===== end thermometer routing helpers =====
+
       for (const [key, value] of Object.entries(sensorList)) {
         // app.debug('key: %d  value: %j', key, value)
         switch (value['type']) {
 	        case 'barometer':
 	          updates.push({"path": "environment.inside.pressure", "value": value.pressure})
             break
-	        case 'thermometer':
-	          updates.push({"path": "electrical.batteries.1.temperature", "value": value.temperature})
+	        case 'thermometer': {
+	          var _path = _thermometerPath(value.name)
+	          updates.push({"path": _path, "value": value.temperature})
+	          if (firstUpdate) {
+	            metas.push({"path": _path, "value": {"units": "K"}})
+	          }
             break
+	        }
 	        case 'volt':
 	          updates.push({"path": "electrical.voltage." + String(voltInstance) + ".value", "value": value.voltage})
 	          updates.push({"path": "electrical.voltage." + String(voltInstance) + ".name", "value": value.name})


### PR DESCRIPTION
## Problem

Every thermometer sensor is currently written to the hard-coded path `electrical.batteries.1.temperature`. Setups with multiple thermometers (e.g. one probe per battery bank plus a cabin / ambient probe) see all four values clobber each other on the same path — only the last-processed one survives, and it's always pinned to battery 1 regardless of which probe it actually came from.

Reproducer: a Pico Yacht with four thermometers (`TEMP SERVICE BATTERY`, `TEMP ENGINE BATTERY`, `TEMP BOW BATTERY`, `TEMP CABIN`). Before this PR, only one value appears in SignalK, on `electrical.batteries.1.temperature`, and it's whichever thermometer the JSON happened to iterate last. After this PR, all four appear on their semantically correct paths.

## Fix

Route each thermometer based on its sensor name, in this priority order (first match wins):

### 1. Battery match (if name mentions BATTERY / BATTERIE / BANK)

A pre-pass over `sensorList` collects every battery sensor's normalized name (uppercase, trim, strip trailing `BATTERY` / `BANK` word). Thermometers whose stripped name contains `BATTERY` / `BANK` try to find a battery via:

  a. exact normalized match
  b. prefix match either direction — handles real-world mismatches like a probe labelled `TEMP BOW BATTERY` mapping to a battery named `BOW THRUSTER BATTERY`
  c. single-token overlap (tokens of length ≥ 3) as a last-resort

On match → `electrical.batteries.<instance>.temperature`.

### 2. Well-known location names → canonical SignalK paths

| Sensor name pattern | SignalK path |
|---|---|
| `CABIN` / `INDOOR` / `INSIDE` / `SALON` | `environment.inside.temperature` |
| `OUTSIDE` / `OUTDOOR` / `AMBIENT` | `environment.outside.temperature` |
| `SEA` / `SEA WATER` / `RAW WATER` | `environment.water.temperature` |
| `ENGINE` / `ENGINE ROOM` | `environment.inside.engineRoom.temperature` |
| `FRIDGE` / `REFRIGERATOR` | `environment.inside.refrigerator.temperature` |
| `FREEZER` | `environment.inside.freezer.temperature` |
| `EXHAUST` | `propulsion.main.exhaustTemperature` |

### 3. Slugified fallback

Anything else gets `environment.inside.<slug>.temperature` (e.g. `TEMP WORKSHOP` → `environment.inside.workshop.temperature`). This means two distinct unknown sensors don't clobber each other, and each gets a predictable, stable path users can decorate with metadata if their preferred convention differs.

## Backwards compatibility

Single-thermometer setups that previously landed at `electrical.batteries.1.temperature` continue to work if the sensor name mentions BATTERY / BANK and there's at least one battery in the list (gets resolved to whichever battery the name matches, often still battery 1). Single-thermometer setups with a non-battery name (e.g. `TEMP CABIN`) will move from `electrical.batteries.1.temperature` to `environment.inside.temperature`, which is the semantically correct destination — a small breaking change but matches what SignalK consumers would expect.

## Tested

Verified on a Pico Yacht (boat in Finland, summer 2026) with the four-thermometer layout described above:

```
electrical.batteries.1.temperature  (SERVICE BATTERY)  : 13.2 °C   ✓
electrical.batteries.2.temperature  (ENGINE BATTERY)   : 12.9 °C   ✓
electrical.batteries.3.temperature  (BOW THRUSTER)     : 14.8 °C   ✓  (token-overlap match)
environment.inside.temperature      (CABIN)            : 19.5 °C   ✓
```

All four are live, distinct, and survive plugin restart cycles.