### PR TITLE
Retry TCP config query when Pico is unresponsive instead of crashing

### DIFF
--- a/pico.py
+++ b/pico.py
@@ -176,25 +176,35 @@ def open_tcp(pico_ip, max_retries=5, retry_delay=5):
 def get_pico_config(pico_ip):
   config = {}
   s = open_tcp(pico_ip)
-  response_list = []
-  message = ('00 00 00 00 00 ff 02 04 8c 55 4b 00 03 ff')
-  message = add_crc(message)
-  response = send_receive(s, message)
-  # debug( "Response: " + response)
-  # Response: 00 00 00 00 00 ff 02 04 8c 55 4b 00 11 ff 01 01 00 00 00 1e ff 02 01 00 00 00 30 ff 32 cf
-  req_count = int(response.split()[19], 16) + 1
-  # debug( "req_count: " + str(req_count))
-
-  for pos in range(req_count):
-    message = ('00 00 00 00 00 ff 41 04 8c 55 4b 00 16 ff 00 01 00 00 00 ' + "%02x" % pos + ' ff 01 03 00 00 00 00 ff 00 00 00 00 ff')
+  if s is None:
+    debug("get_pico_config: open_tcp returned None (Pico TCP unresponsive)")
+    return None
+  try:
+    response_list = []
+    message = ('00 00 00 00 00 ff 02 04 8c 55 4b 00 03 ff')
     message = add_crc(message)
     response = send_receive(s, message)
-    element = parseResponse(response)
-    config[pos] = element
+    # debug( "Response: " + response)
+    # Response: 00 00 00 00 00 ff 02 04 8c 55 4b 00 11 ff 01 01 00 00 00 1e ff 02 01 00 00 00 30 ff 32 cf
+    req_count = int(response.split()[19], 16) + 1
+    # debug( "req_count: " + str(req_count))
 
-  # Close tcp connection
-  s.close()
-  return config
+    for pos in range(req_count):
+      message = ('00 00 00 00 00 ff 41 04 8c 55 4b 00 16 ff 00 01 00 00 00 ' + "%02x" % pos + ' ff 01 03 00 00 00 00 ff 00 00 00 00 ff')
+      message = add_crc(message)
+      response = send_receive(s, message)
+      element = parseResponse(response)
+      config[pos] = element
+
+    return config
+  except Exception as e:
+    debug("get_pico_config failed: " + str(e))
+    return None
+  finally:
+    try:
+      s.close()
+    except Exception:
+      pass
 
 def toTemperature (temp):
   # Unsigned to signed
@@ -269,12 +279,41 @@ client.bind(("", 43210))
 message, addr = client.recvfrom(2048)
 pico_ip = addr[0]
 debug("See Pico at " + str(pico_ip))
-config = get_pico_config(pico_ip)
+
+# Retry config query until it succeeds. Pico's TCP server is intermittently
+# unresponsive (same flakiness users see in the mobile app -- have to restart
+# the app for it to find the server). The 5-retry / 25 s window inside
+# open_tcp is not always enough. Wait, refresh pico_ip from a fresh broadcast,
+# and try again -- forever, until config is obtained.
+sensorList = None
+_retry_attempt = 0
+while sensorList is None:
+    _retry_attempt += 1
+    if _retry_attempt > 1:
+        debug("Config retry attempt " + str(_retry_attempt) + " (waited 30 s)")
+        # Refresh pico_ip from a fresh broadcast in case Pico's IP changed
+        try:
+            client.settimeout(60)
+            _msg, _addr = client.recvfrom(2048)
+            new_ip = _addr[0]
+            if new_ip != pico_ip:
+                debug("Pico IP changed: " + str(pico_ip) + " -> " + str(new_ip))
+                pico_ip = new_ip
+            client.settimeout(None)
+        except Exception as _e:
+            debug("refresh recvfrom failed: " + str(_e))
+            client.settimeout(None)
+    config = get_pico_config(pico_ip)
+    if config:
+        try:
+            sensorList = createSensorList(config)
+        except Exception as _e:
+            debug("createSensorList failed: " + str(_e))
+            sensorList = None
+    if sensorList is None:
+        time.sleep(30)
 debug("CONFIG:")
 debug(config)
-
-# sensorList = {}
-sensorList = createSensorList(config)
 debug("SensorList:")
 debug(sensorList)
 print (json.dumps(sensorList))


### PR DESCRIPTION
## Problem

When the Pico's TCP config server (port 5001) is unresponsive at the moment the plugin starts, the plugin crashes silently and never recovers.

This is **not** a hypothetical failure mode — it's the exact symptom users see in the Simarine Pico mobile app where you have to kill the app and restart it for it to find the server. The Pico's WiFi/TCP layer is intermittently slow to respond after WiFi reassociation, DHCP renewal, or power-cycle.

## Current behaviour

1. `open_tcp()` retries 5 times over 25 s and returns `None` on persistent failure
2. `get_pico_config()` then calls `send_receive(None, message)` which raises:
   ```
   AttributeError: 'NoneType' object has no attribute 'sendall'
   ```
3. Python exits non-zero, no `sensorList` JSON reaches the Node side
4. The plugin's `configRead` flag stays `false`, so every subsequent UDP packet is silently dropped in `socket.on('message', …)`
5. The plugin UI reports "Started" but pushes zero deltas. Only manual SignalK restart recovers it.

For an unattended boat (e.g. monitoring while owner is away) this means **a single Pico flakeout at startup permanently kills monitoring until someone restarts SignalK by hand**.

## Fix

Two small changes to `pico.py`:

### 1. `get_pico_config()` returns `None` cleanly on any failure

```python
def get_pico_config(pico_ip):
  config = {}
  s = open_tcp(pico_ip)
  if s is None:
    debug("get_pico_config: open_tcp returned None (Pico TCP unresponsive)")
    return None
  try:
    # ... existing config query logic ...
    return config
  except Exception as e:
    debug("get_pico_config failed: " + str(e))
    return None
  finally:
    try: s.close()
    except Exception: pass
```

This handles the `s=None` case and also wraps the TCP exchange so any unexpected exception falls back to the same `None`-return path.

### 2. Main script: retry the config query in a loop

Replaces the one-shot `config = get_pico_config(pico_ip)` call with:

```python
sensorList = None
_retry_attempt = 0
while sensorList is None:
    _retry_attempt += 1
    if _retry_attempt > 1:
        debug(f"Config retry attempt {_retry_attempt} (waited 30 s)")
        # Refresh pico_ip from a fresh broadcast in case Pico got a new DHCP lease
        try:
            client.settimeout(60)
            _msg, _addr = client.recvfrom(2048)
            new_ip = _addr[0]
            if new_ip != pico_ip:
                debug(f"Pico IP changed: {pico_ip} -> {new_ip}")
                pico_ip = new_ip
            client.settimeout(None)
        except Exception as _e:
            debug("refresh recvfrom failed: " + str(_e))
            client.settimeout(None)
    config = get_pico_config(pico_ip)
    if config:
        try:
            sensorList = createSensorList(config)
        except Exception as _e:
            debug("createSensorList failed: " + str(_e))
            sensorList = None
    if sensorList is None:
        time.sleep(30)
```

The first attempt still happens immediately, so a healthy Pico sees no behaviour change. If it fails, we sleep 30 s, refresh `pico_ip` from a new UDP broadcast (in case the lease changed), and try again. Loop forever until config is obtained.

After config is in hand we exit the retry loop and fall through to the existing main UDP-decode loop unchanged.

## Verified on real hardware

Tested on a Pico Yacht with the boat WiFi setup typical for marine use:

- **Normal path**: data flowing within 25 s of plugin start, no behaviour change
- **Simulated outage**: blocked TCP to Pico via `iptables`, restarted SignalK; Python stayed alive through the artificial outage (would have crashed unpatched)
- **Recovery**: removed the iptables block; Python completed the config query and exited cleanly; SignalK deltas began flowing within ~25 s

Without this patch, the same sequence requires a manual `docker restart signalk-server` to recover.

## Backwards compatibility

None broken. Healthy Pico setups see identical behaviour. Only failure mode changes from "fatal crash with manual recovery required" to "transparent retry with automatic recovery".