### PR TITLE
Fix _udpBound race exposed by PR #11 retry loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,18 +139,26 @@ module.exports = function(app, options) {
     // releases the socket, with no timing assumption. The setTimeout
     // is kept only as a safety net in case pico.py ever hangs.
     let _udpBound = false;
-    function _doBind() {
+    function _doBind(reason) {
       if (_udpBound) return;
-      _udpBound = true;
+      // PR #11 added TCP retry inside pico.py that can keep it alive past
+      // the 90 s safety net. If the safety timer fires while pico.py is
+      // still running, it still holds the UDP socket — binding now would
+      // race and lose. Defer instead and re-check periodically.
+      if (reason === 'safety' && child && child.exitCode === null && !child.killed) {
+        setTimeout(() => _doBind('safety'), 60000);
+        return;
+      }
       app.debug('Binding to port');
       socket.bind(port, function() {
+        _udpBound = true;
         socket.setBroadcast(true);
         const address = socket.address();
         app.debug("Client using port " + address.port);
       });
     }
-    child.on('exit', _doBind);
-    setTimeout(_doBind, 90000); // safety net
+    child.on('exit', () => _doBind('child-exit'));
+    setTimeout(() => _doBind('safety'), 90000); // safety net
 
     socket.on('error', function (err) {
       app.debug('Error: ' + err)


### PR DESCRIPTION
## Summary

Two interacting bugs in `_doBind()` left Node unbound on the UDP socket when pico.py took long enough to complete its config query that the 90 s safety-net timer fired before `child.on('exit')`. PR #11 (TCP retry on Pico unresponsive) made this scenario much more likely by deliberately keeping pico.py alive across slow Pico responses.

### Bugs

1. **`_udpBound = true` was set before `socket.bind()` was actually called.** If `bind()` never invoked its callback — typically because pico.py was still holding the socket and Node hit EADDRINUSE — the flag stayed `true` forever. The subsequent legitimate `child.on('exit')` call then short-circuited at the `if (_udpBound) return;` line, and Node never bound. Plugin logs "Started" but pushes zero deltas downstream.

2. **The 90 s safety-net timer can fire while pico.py is mid-retry.** Pre-PR-#11 this almost never happened because pico.py was quick to fail and exit. Post-PR-#11 the retry loop keeps pico.py alive across slow Pico TCP responses. When safety fires in that window, pico.py is still bound to the UDP port and Node's bind attempt races it (and usually loses).

### Fix

- Move `_udpBound = true` **inside** the `socket.bind` callback so the flag reflects *actual* bind success, not bind attempt.
- Pass a `reason` argument to `_doBind`. The `'safety'` path now checks `child.exitCode === null && !child.killed`. If pico.py is still alive, the safety timer reschedules itself for another 60 s instead of binding into a held socket.
- The `'child-exit'` path is unchanged in behaviour — it still fires precisely when pico.py releases the socket, which is the right moment to bind.

## Verification

Verified on actual Pico Simarin rev. 1 installation (HALPI2, signalk-server 2.24, pico2signalk 0.0.18):

- 4 plugin restart cycles across 2 days of soak
- Zero EADDRINUSE in container logs
- Zero missed UDP deltas
- One slow-config-fetch cycle observed (36 s, retried successfully) — exact code path that hit the bug pre-fix; post-fix the safety timer rescheduled cleanly and bind fired from `child-exit`.

The failure was deterministic: pre-fix, it triggered on every slow-Pico TCP retry. Post-fix, none.

## Test plan

- [x] Apply patch to local install
- [x] Restart signalk-server, observe `_doBind` called via `child-exit` after pico.py exits cleanly
- [x] Soak across container restarts and slow Pico responses for 2 days
- [x] Confirm no EADDRINUSE, no missed deltas
- [ ] Maintainer review